### PR TITLE
Allow ai v6 in peerDependencies and add repo metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,14 @@
   ],
   "author": "Perplexity AI",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/perplexityai/ai-sdk.git"
+  },
+  "bugs": {
+    "url": "https://github.com/perplexityai/ai-sdk/issues"
+  },
+  "homepage": "https://github.com/perplexityai/ai-sdk#readme",
   "packageManager": "pnpm@10.8.0",
   "devDependencies": {
     "@types/node": "^24.10.1",
@@ -39,7 +47,7 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "ai": "^5.0.0",
+    "ai": "^5.0.0 || ^6.0.0",
     "zod": "^4.0.0"
   }
 }


### PR DESCRIPTION
Closes #2.

Two small changes:

- Widen the `ai` peer range to `^5.0.0 || ^6.0.0` so v6 users stop hitting ERESOLVE on install. The bits this package uses (`tool()` and a `z.object` input schema) didn't change between v5 and v6, and `pnpm build` is green against `ai@6`.
- Add `repository`, `bugs`, and `homepage` so the npm page actually links back here. The reporter mentioned having to hunt for the repo, which tracks.

Tested locally with `ai@6.0.168` + `zod@4` installed against this branch, then `pnpm build`. No code changes, just package metadata.